### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/jmh/java/com/pinterest/jbender/JBenderBenchmark.java
+++ b/src/jmh/java/com/pinterest/jbender/JBenderBenchmark.java
@@ -32,6 +32,8 @@ import java.util.concurrent.ExecutionException;
 import static com.pinterest.jbender.events.recording.Recorder.record;
 
 public class JBenderBenchmark {
+  private static final Logger LOG = LoggerFactory.getLogger(JBenderBenchmark.class);
+
   // @Benchmark
   public Histogram loadtestThroughput() throws SuspendExecution, InterruptedException, ExecutionException {
     final IntervalGenerator intervalGenerator = new ConstantIntervalGenerator(1000);
@@ -64,6 +66,4 @@ public class JBenderBenchmark {
     // Avoid code elimination
     return histogram;
   }
-
-  private static final Logger LOG = LoggerFactory.getLogger(JBenderBenchmark.class);
 }

--- a/src/jmh/java/com/pinterest/jbender/JBenderHttpBenchmark.java
+++ b/src/jmh/java/com/pinterest/jbender/JBenderHttpBenchmark.java
@@ -37,6 +37,8 @@ import static com.pinterest.jbender.events.recording.Recorder.record;
  * Sample HTTP benchmark against {@url https://github.com/puniverse/comsat-gradle-template}
  */
 public class JBenderHttpBenchmark {
+  private static final Logger LOG = LoggerFactory.getLogger(JBenderHttpBenchmark.class);
+
   @Benchmark
   public Histogram loadtestHttpThroughput() throws SuspendExecution, InterruptedException, ExecutionException, IOException {
     final IntervalGenerator intervalGenerator = new ConstantIntervalGenerator(10000000);
@@ -79,6 +81,4 @@ public class JBenderHttpBenchmark {
       return histogram;
     }
   }
-
-  private static final Logger LOG = LoggerFactory.getLogger(JBenderHttpBenchmark.class);
 }

--- a/src/main/java/com/pinterest/jbender/JBender.java
+++ b/src/main/java/com/pinterest/jbender/JBender.java
@@ -32,6 +32,8 @@ import java.util.concurrent.TimeUnit;
  * JBender has static methods for running load tests by throughput or concurrency.
  */
 public final class JBender {
+  private static final Logger LOG = LoggerFactory.getLogger(JBender.class);
+
   /**
    * Run a load test with the given throughput, using as many fibers as necessary.
    *
@@ -418,6 +420,4 @@ public final class JBender {
           new TimingEvent<>(curWaitNanos, outcome.execTime, curOverageNanos, outcome.exception));
     }
   }
-
-  private static final Logger LOG = LoggerFactory.getLogger(JBender.class);
 }

--- a/src/main/java/com/pinterest/jbender/executors/SleepyRequestExecutor.java
+++ b/src/main/java/com/pinterest/jbender/executors/SleepyRequestExecutor.java
@@ -16,6 +16,9 @@ import co.paralleluniverse.fibers.SuspendExecution;
 import co.paralleluniverse.strands.Strand;
 
 public class SleepyRequestExecutor<Q> implements RequestExecutor<Q, Void> {
+  private final int sleepMillis;
+  private final int sleepNanos;
+
   public SleepyRequestExecutor(int sleepMillis, int sleepNanos) {
     this.sleepMillis = sleepMillis;
     this.sleepNanos = sleepNanos;
@@ -26,7 +29,4 @@ public class SleepyRequestExecutor<Q> implements RequestExecutor<Q, Void> {
     Strand.sleep(sleepMillis, sleepNanos);
     return null;
   }
-
-  private final int sleepMillis;
-  private final int sleepNanos;
 }

--- a/src/main/java/com/pinterest/jbender/intervals/ConstantIntervalGenerator.java
+++ b/src/main/java/com/pinterest/jbender/intervals/ConstantIntervalGenerator.java
@@ -13,6 +13,8 @@ limitations under the License.
 package com.pinterest.jbender.intervals;
 
 public class ConstantIntervalGenerator implements IntervalGenerator {
+  private final long interval;
+
   public ConstantIntervalGenerator(long interval) {
     this.interval = interval;
   }
@@ -21,6 +23,4 @@ public class ConstantIntervalGenerator implements IntervalGenerator {
   public long nextInterval(long nanoTimeSinceStart) {
     return interval;
   }
-
-  private final long interval;
 }

--- a/src/main/java/com/pinterest/jbender/intervals/ExponentialIntervalGenerator.java
+++ b/src/main/java/com/pinterest/jbender/intervals/ExponentialIntervalGenerator.java
@@ -18,6 +18,9 @@ import java.util.Random;
  * Poisson distribution request interval generator.
  */
 public class ExponentialIntervalGenerator implements IntervalGenerator {
+  private final double nanosPerQuery;
+  private final Random rand;
+
   public ExponentialIntervalGenerator(int queriesPerSecond) {
     nanosPerQuery = 1000000000.0 / queriesPerSecond;
     this.rand = new Random();
@@ -27,7 +30,4 @@ public class ExponentialIntervalGenerator implements IntervalGenerator {
   public long nextInterval(long nanoTimeSinceStart) {
     return (long) (-Math.log(rand.nextDouble()) * this.nanosPerQuery);
   }
-
-  private final double nanosPerQuery;
-  private final Random rand;
 }

--- a/src/main/java/com/pinterest/jbender/util/WaitGroup.java
+++ b/src/main/java/com/pinterest/jbender/util/WaitGroup.java
@@ -20,6 +20,9 @@ import co.paralleluniverse.strands.Strand;
  * Simplified phaser supporting up to {@code Long.MAX_VALUE} fibers.
  */
 public class WaitGroup {
+  private volatile Strand waiter;
+  private AtomicLong running;
+
   public WaitGroup() {
     running = new AtomicLong();
     waiter = null;
@@ -42,7 +45,4 @@ public class WaitGroup {
       Strand.park();
     }
   }
-
-  private volatile Strand waiter;
-  private AtomicLong running;
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 50 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
