### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/pinterest/jbender/JBender.java
+++ b/src/main/java/com/pinterest/jbender/JBender.java
@@ -34,6 +34,8 @@ import java.util.concurrent.TimeUnit;
 public final class JBender {
   private static final Logger LOG = LoggerFactory.getLogger(JBender.class);
 
+  private JBender() {}
+
   /**
    * Run a load test with the given throughput, using as many fibers as necessary.
    *


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 30 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
