### PR TITLE
squid:S1068 - Unused private fields should be removed

### DIFF
--- a/src/jmh/java/com/pinterest/jbender/JBenderBenchmark.java
+++ b/src/jmh/java/com/pinterest/jbender/JBenderBenchmark.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutionException;
 import static com.pinterest.jbender.events.recording.Recorder.record;
 
 public class JBenderBenchmark {
-  private static final Logger LOG = LoggerFactory.getLogger(JBenderBenchmark.class);
 
   // @Benchmark
   public Histogram loadtestThroughput() throws SuspendExecution, InterruptedException, ExecutionException {

--- a/src/jmh/java/com/pinterest/jbender/JBenderHttpBenchmark.java
+++ b/src/jmh/java/com/pinterest/jbender/JBenderHttpBenchmark.java
@@ -37,7 +37,6 @@ import static com.pinterest.jbender.events.recording.Recorder.record;
  * Sample HTTP benchmark against {@url https://github.com/puniverse/comsat-gradle-template}
  */
 public class JBenderHttpBenchmark {
-  private static final Logger LOG = LoggerFactory.getLogger(JBenderHttpBenchmark.class);
 
   @Benchmark
   public Histogram loadtestHttpThroughput() throws SuspendExecution, InterruptedException, ExecutionException, IOException {

--- a/src/main/java/com/pinterest/jbender/util/ConnectionPool.java
+++ b/src/main/java/com/pinterest/jbender/util/ConnectionPool.java
@@ -50,7 +50,6 @@ public class ConnectionPool<T extends Closeable> {
     T get() throws IOException, SuspendExecution;
   }
 
-  private static final Logger LOG = LoggerFactory.getLogger(ConnectionPool.class);
   private final SuspendableSupplierWithIO<T> supplier;
   private final Channel<T> pool;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1068 - Unused private fields should be removed.
This pull request removes 15 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
George Kankava
